### PR TITLE
Update link and end date for keynote nomination data

### DIFF
--- a/_data/conf.yml
+++ b/_data/conf.yml
@@ -233,8 +233,8 @@ show-sponsorship-charts: false
 
 keynote-proposals:
   show: false
-  submission-form: 'https://wiki.code4lib.org/2025_Keynote_Speakers_Nominations'
-  end-date: '2024-11-22'
+  submission-form: 'https://wiki.code4lib.org/2026_Keynote_Speakers_Nominations'
+  end-date: '2025-10-24'
 
 workshop-proposals:
   show: false


### PR DESCRIPTION
Fixes https://github.com/code4lib/2026.code4lib.org/issues/12

To be merged on October 13

The issue said "Take down date: October 24th.".. I wasn't sure if that should also be the end date in the data, or just a date to make a further change.