### PR TITLE
Add talk proposals to home pg

### DIFF
--- a/_data/conf.yml
+++ b/_data/conf.yml
@@ -242,9 +242,9 @@ workshop-proposals:
   end-date: '2024-11-27'
 
 talk-proposals:
-  show: false
-  submission-form: 'https://forms.gle/v3QmnrA6G5DiiLVi9'
-  end-date: '2024-10-11'
+  show: true
+  submission-form: 'https://forms.gle/mqYCABhthmT7hfM3A'
+  end-date: '2024-10-27'
 
 panel-proposals:
   show: false


### PR DESCRIPTION
This adds the talk proposals, they're open now so we should immediately update the website. After this is merged, I will create a partner PR to turn off the proposals link and set myself a reminder to merge it.

Check details against email announcement to listserv or post in Code4Lib Slack (general and con channels).
