### PR TITLE
script to generate schedule YAML from the schedule spreadsheet

### DIFF
--- a/_scripts/examples/schedule.csv
+++ b/_scripts/examples/schedule.csv
@@ -1,0 +1,37 @@
+Day,Start,Description
+1,8:30,Registration  
+1,9:30,Announcements
+1,9:45,Opening Keynote
+1,10:30,Break
+1,10:45,Group 1 Talks
+1,12:00,Lunch
+1,13:00,Announcements
+1,13:15,Group 2 Talks
+1,14:45,Break
+1,15:00,Lightning Talks
+1,16:00,Group 3 Talks
+1,17:00,Announcements
+1,17:15,End
+2,8:45,Registration  
+2,9:00,Announcements
+2,9:15,Group 4 Talks
+2,10:50,Break
+2,11:10,Lightning Talks
+2,12:00,Lunch
+2,13:15,Announcements
+2,13:30,Group 5 Talks
+2,14:30,Breakouts
+2,15:45,Break
+2,16:00,Posters
+2,16:30,Group 6 Talks
+2,17:20,Announcements
+2,17:30,End
+3,8:30,Registration  
+3,9:00,Announcements
+3,9:15,Closing Keynote
+3,10:00,Lightning Talks
+3,10:45,Break
+3,11:05,Breakouts
+3,11:50,Group 7 Talks
+3,12:35,Announcements
+3,12:45,End

--- a/_scripts/schedule.rb
+++ b/_scripts/schedule.rb
@@ -1,0 +1,47 @@
+#!/usr/bin/env ruby
+
+require "csv"
+require "time"
+
+prev_day = nil
+prev_start = nil
+prev_desc = nil
+
+fmt = "%H:%M"
+
+CSV.foreach(ARGV[0], headers: true).each do |row|
+  day   = row["Day"]
+  start = row["Start"]
+  desc  = row["Description"].strip
+
+  if prev_day != nil
+    # we have data to output
+    d1 = Time.parse(prev_start)
+    d2 = Time.parse(start)
+    clockface = "#{d1.strftime("%l.%M").strip}.png"
+
+    puts "- timeImg: #{clockface}"
+    puts "  time: #{d1.strftime(fmt)}-#{d2.strftime(fmt)}"
+    puts "  day#{day}: true"
+    puts "  title: #{prev_desc}"
+
+    if prev_desc == "Opening Keynote"
+      puts "  groupId: key-open"
+    elsif prev_desc == "Closing Keynote"
+      puts "  groupId: key-close"
+    elsif prev_desc =~ /Group (\d) Talks/
+      puts "  groupId: #{$1}"
+    end
+  end
+
+  if desc == "End"
+    # end of day, reset
+    prev_day = nil
+    prev_start = nil
+    prev_desc = nil
+  else
+    prev_day = day
+    prev_start = start
+    prev_desc = desc
+  end
+end

--- a/_scripts/schedule.rb
+++ b/_scripts/schedule.rb
@@ -9,6 +9,10 @@ prev_desc = nil
 
 fmt = "%H:%M"
 
+def livestream?(title)
+  title.match?(/Announcements/) || title.match?(/Talks/) || title.match?(/Keynote/)
+end
+
 CSV.foreach(ARGV[0], headers: true).each do |row|
   day   = row["Day"]
   start = row["Start"]
@@ -23,6 +27,7 @@ CSV.foreach(ARGV[0], headers: true).each do |row|
     puts "- timeImg: #{clockface}"
     puts "  time: #{d1.strftime(fmt)}-#{d2.strftime(fmt)}"
     puts "  day#{day}: true"
+    puts "  livestream: #{livestream?(prev_desc)}"
     puts "  title: #{prev_desc}"
 
     if prev_desc == "Opening Keynote"

--- a/_scripts/talks.rb
+++ b/_scripts/talks.rb
@@ -1,6 +1,7 @@
 #!/usr/bin/env ruby
 
 require "csv"
+require "time"
 require "active_support/all"
 
     def parameterize(string, separator: "-")
@@ -29,6 +30,9 @@ CSV.foreach(ARGV[0], headers: true).each do |row|
   group = row["group"]
   spot = row["spot"]
 
+  # fixup time
+  time = Time.parse(time).strftime("%H:%M")
+
   fn = "_posts/#{day}-#{parameterize(title)}.md"
   puts fn
   File.open(fn, "w") do |f|
@@ -42,7 +46,7 @@ CSV.foreach(ARGV[0], headers: true).each do |row|
     f.puts "day: #{dayno}"
     f.puts "group: #{group}"
     f.puts "spot: #{spot}"
-    f.puts "location: frist" # XXX is this used?
+    #f.puts "location: frist" # XXX is this used?
     f.puts "speakers:"
     f.puts "- #{parameterize(speaker1)}"
     f.puts "- #{parameterize(speaker2)}" if speaker2


### PR DESCRIPTION
This script takes a CSV file modeled after the schedule spreadsheet that is used to schedule talks, breakouts, lunch, etc, etc.

Also creates stub speaker entries (fixes #45) and uses 24-hour time as appropriate (fixes #46)