### PR TITLE
Schedule times are not a heading

### DIFF
--- a/_includes/presentation_timeline.html
+++ b/_includes/presentation_timeline.html
@@ -55,12 +55,12 @@
                         {% endif %}
                     </div>
                     <div class="col-sm-5 col-12 text-right">
-                        <h2 class="cd-timeline-content-title">
+                        <p class="cd-timeline-content-title cd-timeline-content-time"><strong>
                             {% capture eventTime %}{{ event.time | replace: '-', ' ' }}{% endcapture %}
                             {% capture beginTime %}{{ eventTime | truncatewords: 1, '' }}{% endcapture %}
                             {% capture endTime %}{{ eventTime | replace: beginTime, '' }}{% endcapture %}
                             {{ beginTime | date: "%l:%M%p" | strip }} to {{ endTime | date: "%l:%M%p" | strip }}
-                        </h2>
+                        </strong></p>
                         <div class="timezone">{{ site.data.conf.timezone }} Time</div>
                     </div>
                 </div>
@@ -72,7 +72,7 @@
                                 {% if event.groupId == 'key-open' %}
                                 {% elsif event.groupId == 'key-close' %}
                                 {% else %}
-                                    
+
                                 <h3 class="h4 talk-title">{% if talk.status == "canceled" %}<s>{% endif %}<a href="{{ talk.url }}">{{ talk.title }}</a>{% if talk.status == "canceled" %}</s>{% endif %}</h3>
                                 {% endif %}
                             </div>

--- a/assets/_scss/_timeline.scss
+++ b/assets/_scss/_timeline.scss
@@ -208,6 +208,14 @@
   font-size: 14px;
 }
 
+.cd-timeline-content .cd-timeline-content-time {
+  font-size: 20px;
+  letter-spacing: .02em;
+  line-height: 1.1;
+  margin: 0;
+  padding: 0;
+}
+
 .cd-timeline-content .cd-read-more,
 .cd-timeline-content .cd-date {
   display: inline-block;


### PR DESCRIPTION
From discussion on #50 — the talk times on [the schedule](https://2026.code4lib.org/schedule/day-1/) are `h2` headings. I think the logical hierarchy of the schedule page is h1 Page Title > h2 Talk Group > h3 Individual talk titles. I don't think the times rise to the level of a heading, but it is debatable.

Before this PR WAVE should show twice as many **Heading level 2** elements. For instance, the schedule day 1 has 24 level 2 headings before and only 12 afterwards. This PR shouldn't conflict with #50 and can be merged independently.